### PR TITLE
fix typo duplicate

### DIFF
--- a/rmt-helm/templates/front-deployment.yaml
+++ b/rmt-helm/templates/front-deployment.yaml
@@ -21,8 +21,6 @@ spec:
       component: {{ $component }}
   template:
     metadata:
-
-    metadata:
       annotations:
         checksum/config: {{ include (printf "%s/%s-configmap.yaml" $.Template.BasePath $component) . | sha256sum }}
       {{- with .Values.podAnnotations }}


### PR DESCRIPTION
metadata key is obviously duplicated. Does not seem to error out on helm deployment, but failed on a podman play attempt of the rendered template.
