### PR TITLE
Update Chart to version 1.0.4

### DIFF
--- a/rmt-helm/Chart.yaml
+++ b/rmt-helm/Chart.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: suse/rmt-helm:latest
-#!BuildTag: suse/rmt-helm:1.0.3
+#!BuildTag: suse/rmt-helm:1.0.4
 apiVersion: v2
 name: rmt
 description: SUSE Repository Mirroring Tool (RMT) Chart
@@ -18,10 +18,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.8.0"
+appVersion: "2.14.0"

--- a/rmt-helm/values.yaml
+++ b/rmt-helm/values.yaml
@@ -9,7 +9,7 @@ db:
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     # -- db image tag
-    tag: "10.5"
+    tag: "10.6"
   storage:
     class:
     # -- db storage volume space requirements
@@ -36,14 +36,14 @@ app:
       repository: registry.suse.com/suse/rmt-mariadb-client
       pullPolicy: Always
       # Overrides the image tag whose default is the chart appVersion.
-      tag: "10.5"
+      tag: "10.6"
   image:
     # -- RMT server image
     repository: registry.suse.com/suse/rmt-server
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     # -- RMT server image tag
-    tag: "2.8"
+    tag: "2.14"
   mysql:
     # -- mysql host to connect to (default target is db container)
     host:
@@ -73,14 +73,14 @@ front:
       repository: registry.suse.com/bci/bci-micro
       pullPolicy: Always
       # Overrides the image tag whose default is the chart appVersion.
-      tag: "15.3"
+      tag: "15.5"
   image:
     # -- Nginx image
-    repository: registry.suse.com/suse/rmt-nginx
+    repository: registry.suse.com/suse/nginx
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     # -- Nginx image tag
-    tag: "1.19"
+    tag: "1.21"
   service:
     # -- Nginx service port
     port: 80


### PR DESCRIPTION
Image update for rmt-server 2.8 => 2.14

Webserver now uses registry.suse.com/suse/nginx
instead of specific rmt-nginx
rmt-nginx 1.19 => nginx 1.21

MariaDB update 10.5 => 10.6

bci-micro 15.3 => 15.5