### PR TITLE
Set default value for helm repo tag

### DIFF
--- a/rmt-helm/values.yaml
+++ b/rmt-helm/values.yaml
@@ -43,7 +43,7 @@ app:
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     # -- RMT server image tag
-    tag: "latest"
+    tag: "2.14"
   mysql:
     # -- mysql host to connect to (default target is db container)
     host:

--- a/rmt-helm/values.yaml
+++ b/rmt-helm/values.yaml
@@ -43,7 +43,7 @@ app:
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     # -- RMT server image tag
-    tag: "2.8"
+    tag: "latest"
   mysql:
     # -- mysql host to connect to (default target is db container)
     host:


### PR DESCRIPTION
Use ~~`default`~~ `2.14` tag for rmt-server image container. Customers should be able to run rmt without extra steps. This will also encourage customers to use the latest versions with new features.