### PR TITLE
Fix wrong indentation of tls section

### DIFF
--- a/rmt-helm/values.yaml
+++ b/rmt-helm/values.yaml
@@ -105,10 +105,10 @@ ingress:
         - path: "/"
           pathType: Prefix
   tls:
-  - secretName: rmt-cert
-    hosts:
-    # -- DNS name at which the RMT service will be accessible from clients
-    - chart-example.local
+    - secretName: rmt-cert
+      hosts:
+        # -- DNS name at which the RMT service will be accessible from clients
+        - chart-example.local
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/rmt-helm/values.yaml
+++ b/rmt-helm/values.yaml
@@ -1,3 +1,5 @@
+---
+
 # Default values for rmt.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.


### PR DESCRIPTION
This PR consists of two commits for `values.yaml`:

1. Fix the indentation for the `tls` section (missing indentation level)
2. Add missing yaml header