### PR TITLE
Add SCC host configuration option

### DIFF
--- a/rmt-helm/questions.yml
+++ b/rmt-helm/questions.yml
@@ -16,7 +16,13 @@ questions:
   required: true
   type: string
   group: "SUSE Customer Center"
-
+- variable: app.scc.host
+  default: https://scc.suse.com
+  description: "SCC Host address"
+  label: "SCC Host"
+  required: true
+  type: string
+  group: "SUSE Customer Center"
 #RMT Configuration
 
 - variable: app.service.port

--- a/rmt-helm/templates/20-app-configmap.yaml
+++ b/rmt-helm/templates/20-app-configmap.yaml
@@ -5,6 +5,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "rmt.fullname" . }}-{{ $component }}
 data:
+  scc_host: {{ .Values.app.scc.host }}
   products_enable: |-
     {{- range .Values.app.scc.products_enable}}
     {{ . }}

--- a/rmt-helm/templates/20-app-deployment.yaml
+++ b/rmt-helm/templates/20-app-deployment.yaml
@@ -84,6 +84,11 @@ spec:
             configMapKeyRef:
               name: {{ include "rmt.fullname" . }}-{{ $component }}
               key: products_disable
+        - name: SCC_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "rmt.fullname" . }}-{{ $component }}
+              key: scc_host
         {{- with .Values.app.env }}
           {{- if .http_proxy }}
         - name: http_proxy

--- a/rmt-helm/values.yaml
+++ b/rmt-helm/values.yaml
@@ -54,6 +54,7 @@ app:
     # -- RMT server storage volume requirements. This can vary greatly depending on the number of modules to mirror.
     size: 300Mi
   scc:
+    host: https://scc.suse.com/connect
     # -- Enable or Disable the sync with SCC
     enabled: true
     # -- SCC username


### PR DESCRIPTION
## How to test/demo
prereq: a working minikube installation. Start cluster with `minikube start`

<details>
<summary>test.yaml</summary>

```yaml

app:
  storage:
    class: local-path
  scc:
    host: http://localhost:3000/connect
    username: "xxxxx"
    password: "xxxxx"
    products_enable:
      - SLES/15.6/x86_64
      - sle-module-python2/15.6/x86_64
    products_disable:
      - sle-module-legacy/15.3/x86_64
      - sle-module-cap-tools/15.3/x86_64
db:
  storage:
    class: local-path
ingress:
  enabled: true
  hosts:
    - host: chart-example.local
      paths:
        - path: "/"
          pathType: Prefix
  tls:
    - secretName: rmt-cert
      hosts:
        - chart-example.local
```
</details>

Run helm upgrade: `helm upgrade --install rmt -f rmt-helm/test_values.yaml rmt-helm/`
To verify:
- access the pod with `kubectl exec -it <your rmt app pod> -- /bin/bash`
- run `env | grep SCC_HOST`
