### PR TITLE
Removing subPath to fix mount issues

### DIFF
--- a/kiosk/templates/daemonset.yaml
+++ b/kiosk/templates/daemonset.yaml
@@ -46,7 +46,6 @@ spec:
             {{- end }}
             {{- with .Values.X11.xinitrcOverride }}
             - mountPath: /etc/X11/xinit/
-              subPath: xinitrc
               name: xinitrc
             {{- end }}
             {{- with .Values.X11.customKeyboardLayout }}


### PR DESCRIPTION
This fixes an issue where the container wouldn't start correctly when an xinitrcOverride was set.