### PR TITLE
Fixing a few issues

### DIFF
--- a/kiosk/Chart.yaml
+++ b/kiosk/Chart.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #!BuildTag: suse/kiosk/kiosk-chart:latest
-#!BuildTag: suse/kiosk/kiosk-chart:1.0.0
+#!BuildTag: suse/kiosk/kiosk-chart:1.0.1
 apiVersion: v2
 name: kiosk
 description: Manage kiosk or HID workloads using Kubernetes
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/kiosk/templates/daemonset.yaml
+++ b/kiosk/templates/daemonset.yaml
@@ -46,13 +46,16 @@ spec:
             {{- end }}
             {{- with .Values.X11.xinitrcOverride }}
             - mountPath: /etc/X11/xinit/
-              subPath: xinitrc
               name: xinitrc
             {{- end }}
             {{- with .Values.X11.customKeyboardLayout }}
             - name: xkb-config
               mountPath: /usr/share/X11/xkb/symbols/custom_layout
               subPath: custom_layout
+            {{- end }}
+            {{- with .Values.X11.customBackgroundConfigMap }}
+            - name: custom_background
+              mountPath: /usr/share/wallpapers/SLEdefault/contents/images
             {{- end }}
         - name: pulseaudio
           image: {{ .Values.pulseaudio.image.repository }}:{{ .Values.pulseaudio.image.tag }}
@@ -164,6 +167,14 @@ spec:
         - name: {{ .name }}
           image: "{{ .image.repository }}:{{ .image.tag }}"
           imagePullPolicy: {{ .image.pullPolicy }}
+          {{- with .command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             {{- range .ports }}
             - containerPort: {{ .targetPort }}

--- a/kiosk/templates/daemonset.yaml
+++ b/kiosk/templates/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
               subPath: custom_layout
             {{- end }}
             {{- with .Values.X11.customBackgroundConfigMap }}
-            - name: custom_background
+            - name: custom-background
               mountPath: /usr/share/wallpapers/SLEdefault/contents/images
             {{- end }}
         - name: pulseaudio
@@ -257,4 +257,9 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: {{ .Values.workload.shm.sizeLimit }}
+        {{- end }}
+        {{- if .Values.X11.customBackgroundConfigMap }}
+        - name: custom-background
+          configMap:
+            name: {{ .Values.X11.customBackgroundConfigMap }}
         {{- end }}

--- a/kiosk/values.yaml
+++ b/kiosk/values.yaml
@@ -14,6 +14,9 @@ X11:
   customKeyboardLayout: null
   # Add additional commands prior to startx (such as xrandr).
   xinitrcOverride: null
+  # Allow for setting a custom background image using an existing configmap as the source
+  # The named configmap must be in the same namespace this chart is installed in 
+  customBackgroundConfigMap: null
 
 pulseaudio:
   image:
@@ -77,6 +80,10 @@ workload:
 #       repository: registry.opensuse.org/home/atgracey/wallboardos/15.6/vnc
 #       tag: "vnc"
 #       pullPolicy: IfNotPresent
+#     command: ["bash"]
+#     args:
+#       - -c
+#       - x11vnc -shared -forever
 #     ports:
 #       - name: vnc
 #         targetPort: 5900
@@ -112,7 +119,7 @@ workload:
 
 # # Select where the containers are deployed.
 # nodeSelector:
-#   disktype: ssd
+#   displayAttached: true
 
 # # For adding custom hostnames for the workload to use.
 # hostAliases:


### PR DESCRIPTION
There were 3 initial issues found by the customer:
- The xinitrc mount doesn't allow the container to start without removing the subPath
- They would like to be able to specify the command and args that are used in the additionalWorkload
- At some point I lost the yaml to set a custom background image via configmap (which is needed to allow for improved branding at startup)