### PR TITLE
make front container optional

### DIFF
--- a/rmt-helm/README.md
+++ b/rmt-helm/README.md
@@ -66,6 +66,8 @@ app:
     products_disable:
       - sle-module-legacy/15.3/x86_64
       - sle-module-cap-tools/15.3/x86_64
+front:
+  enabled: true
 ingress:
   enabled: true
   hosts:
@@ -91,7 +93,8 @@ The required values in the custom value file are as follows:
 - `app.scc.products_disable` list of products to exclude from mirroring.
 - `app.storage.class` Kubernetes storageclass.
 - `db.storage.class` Kubernetes storageclass.
-- `ingress.enabled` Enable or disable ingress.
+- `front.enabled` Enable or disable front.
+- `ingress.enabled` Enable or disable ingress. Also enable "front" if you want "ingress".
 - `ingress.hosts[0]` DNS name at which the RMT service is be accessible from clients.
 - `ingress.tls[0].hosts[0]` DNS name at which the RMT service is be accessible from clients.
 - `ingress.tls[0].secretName` TLS ingress certificate.

--- a/rmt-helm/templates/30-front-configmap.yaml
+++ b/rmt-helm/templates/30-front-configmap.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.front.enabled -}}
 {{- $component := "front" -}}
 apiVersion: v1
 kind: ConfigMap
@@ -57,3 +58,4 @@ data:
             alias /srv/www/htdocs/index.html;
         }
     }
+{{- end }}

--- a/rmt-helm/templates/30-front-deployment.yaml
+++ b/rmt-helm/templates/30-front-deployment.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.front.enabled -}}
 {{- $component := "front" -}}
 {{- $image := .Values.front.image -}}
 {{- $initImage := .Values.front.init.image -}}
@@ -67,3 +68,4 @@ spec:
         image: "{{ $initImage.repository }}:{{ $initImage.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ $initImage.pullPolicy | default "IfNotPresent" }}
         command: ['/bin/sh', '-c', 'until getent hosts "{{ include "rmt.fullname" . }}-app"; do echo waiting for rmt-server; sleep 2; done;']
+{{- end }}

--- a/rmt-helm/templates/30-front-ingress.yaml
+++ b/rmt-helm/templates/30-front-ingress.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled .Values.front.enabled -}}
 {{- $component := "front" -}}
 {{- $fullName := include "rmt.fullname" . -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}

--- a/rmt-helm/templates/30-front-service.yaml
+++ b/rmt-helm/templates/30-front-service.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.front.enabled -}}
 {{- $component := "front" -}}
 apiVersion: v1
 kind: Service
@@ -16,3 +17,4 @@ spec:
   selector:
     {{- include "rmt.selectorLabels" . | nindent 4 }}
     component: {{ $component }}
+{{- end }}

--- a/rmt-helm/values.yaml
+++ b/rmt-helm/values.yaml
@@ -80,6 +80,8 @@ app:
       schedule: "30 2 * * *"
 
 front:
+  # -- Enable or disable the front nginx container
+  enabled: true
   init:
     image:
       repository: registry.suse.com/bci/bci-micro


### PR DESCRIPTION
In case the RMT is only used as a mirroring tool, the front container is not needed (as is the ingress controller). This PR introduces a tunable

```
front:
  # -- Enable or disable the front nginx container
  enabled: true
```